### PR TITLE
add a test for prefixes with url's, fix a formatting bug where filename ...

### DIFF
--- a/lib/connect-cachify.js
+++ b/lib/connect-cachify.js
@@ -151,7 +151,7 @@ var hashify = function (filename, hash) {
       filename[0] === '/') {
     return format('/%s%s%s', opts.prefix, hash, filename);
   } else {
-    return format('%s%s/%s', opts.prefix, hash, filename);
+    return format('%s%s%s%s', opts.prefix, hash, filename[0] === '/' ? '' : '/', filename);
   }
 };
 

--- a/test/connect-cachify-test.js
+++ b/test/connect-cachify-test.js
@@ -164,6 +164,45 @@ exports.setup = nodeunit.testCase({
       test.done();
     });
   },
+  "Production mode with absolute URL in prefix": function (test) {
+    var assets = make_assets(),
+        req = {
+          url: '/v/d41d8cd98f/js/main.min.js'
+        },
+        resp = {
+          state: {},
+          local: function (key, value) {
+            this.state[key] = value;
+          },
+          setHeader: function (key, value) {
+            this.state[key] = value;
+            if (!this.state['header']) this.state['header'] = 0;
+            this.state['header'] += 1;
+          },
+          on: function (name, cb) {
+
+          }
+        },
+        mddlwr;
+    mddlwr = cachify.setup(
+      assets, {
+        root: '/tmp',
+        prefix: 'http://example.com/v/'
+      });
+    var link = cachify.cachify_js("/js/main.min.js");
+    test.equal(link, '<script src="http://example.com/v/d41d8cd98f/js/main.min.js"></script>',
+              "Hashes in all urls in production");
+    var file = cachify.cachify("/js/main.min.js");
+    test.equal(file, "http://example.com/v/d41d8cd98f/js/main.min.js");
+    mddlwr(req, resp, function () {
+      test.ok(resp.state.cachify_js);
+      test.ok(resp.state.cachify_css);
+      test.ok(resp.state.cachify);
+      test.ok(resp.state.header > 0);
+      test.equal(req.url, '/js/main.min.js');
+      test.done();
+    });
+  },
   "Custom prefix works with non-file assets": function (test) {
     var assets = make_assets(),
         req = {


### PR DESCRIPTION
...starts with '/'

This fixes a bug when using absolute urls in prefixes where cachify puts a double slash before the filename (i.e. `https://static.personatest.org/v/5cb95f4060//production/browserid.css`)

mind reviewing, merging, and pushing a new version?
