### PR TITLE
Express3 support

### DIFF
--- a/lib/connect-cachify.js
+++ b/lib/connect-cachify.js
@@ -51,9 +51,18 @@ exports.setup = function (assets, options) {
         m = req.url.match(new RegExp(fmt)),
         true_path, exists;
 
-    resp.local('cachify_js', cachify_js);
-    resp.local('cachify_css', cachify_css);
-    resp.local('cachify', cachify);
+    if (typeof resp.local === 'function') {
+      resp.local('cachify_js', cachify_js);
+      resp.local('cachify_css', cachify_css);
+      resp.local('cachify', cachify);
+    }
+    else if (typeof resp.locals === 'function') {
+      resp.locals({
+        cachify_js: cachify_js,
+        cachify_css: cachify_css,
+        cachify: cachify
+      });
+    }
     if (m && m.index === 0) {
       // 10 first characters of md5 + 1 for slash
       true_path = req.url.slice(prefix.length + 11); 


### PR DESCRIPTION
Hi,

I want to use cachify in an express 3 project but I get this error : 

> TypeError: Object #<ServerResponse> has no method 'local'
> at Object.exports.setup [as handle] (node_modules/connect-cachify/lib/connect-cachify.js:54:10)

_resp.local_ does not exist anymore in express3, it has been replaced with _resp.locals_
So I replaced the 3 lines using resp.local with the following code and it works  :

```
resp.locals({
      'cachify_js': cachify_js,
      'cachify_css': cachify_css,
      'cachify': cachify
    });
```

Is it possible to support express 3 without breaking compatibility with older versions ?

Thanks
