### PR TITLE
Allow development resources to contain fragment identifiers.

### DIFF
--- a/lib/connect-cachify.js
+++ b/lib/connect-cachify.js
@@ -64,7 +64,7 @@ exports.setup = function (assets, options) {
     }
     if (m && m.index === 0) {
       // 10 first characters of md5 + 1 for slash
-      true_path = req.url.slice(prefix.length + 11); 
+      true_path = req.url.slice(prefix.length + 11);
       exists = false;
 
       if (opts.prefix !== '' &&
@@ -120,20 +120,27 @@ exports.setup = function (assets, options) {
  * foo.js                    -> a998d8e98f/foo.js
  * http://example.com/foo.js -> http://example.com/foo.js
  */
-var hashify = function (filename, hash) {
-  if (typeof filename !== 'string')
-    throw "cachify ERROR, expected string for filename, got " + filename;
-  if (filename.indexOf('://') !== -1) {
-    return filename;
+var hashify = function (resource, hash) {
+  if (typeof resource !== 'string')
+    throw "cachify ERROR, expected string for resource, got " + resource;
+  if (resource.indexOf('://') !== -1) {
+    return resource;
   }
+
   if (! hash && opts.global_hash) {
     hash = opts.global_hash;
   }
 
   if (opts.production !== true &&
       opts.debug === false) {
-    return filename;
+    return resource;
   }
+
+  // fragment identifiers on URLs are never sent to the server and they
+  // should not exist on the filename. When looking up the resource on
+  // disk, do so without the fragment identifier.
+  var filename = resource.replace(/#.*$/, '');
+
   if (hash) {
     // No-op, specifing a hash skips all this craziness
   } else if (_cache[filename] && _cache[filename].hash) {
@@ -144,22 +151,24 @@ var hashify = function (filename, hash) {
     var md5 = crypto.createHash('md5');
     try {
       var data = fs.readFileSync(path.join(opts.root, filename));
+
       md5.update(data);
       // Expensive, maintain in-memory cache
       if (! _cache[filename]) _cache[filename] = {exists: true};
       hash = _cache[filename].hash = md5.digest('hex').slice(0, 10);
     } catch (e) {
       // Not intersting to cache, programmer error?
+      exports.uncached_resources.push(resource);
       console.error('Cachify bailing on hash... no such file ' + filename );
       console.error(e);
-      return filename;
+      return resource;
     }
   }
   if (opts.prefix.indexOf('://') === -1 &&
-      filename[0] === '/') {
-    return format('/%s%s%s', opts.prefix, hash, filename);
+      resource[0] === '/') {
+    return format('/%s%s%s', opts.prefix, hash, resource);
   } else {
-    return format('%s%s%s%s', opts.prefix, hash, filename[0] === '/' ? '' : '/', filename);
+    return format('%s%s%s%s', opts.prefix, hash, resource[0] === '/' ? '' : '/', resource);
   }
 };
 
@@ -207,3 +216,5 @@ var no_url = function (prefix) {
 var escape_regex = function (str) {
   return str.replace('/', '\/');
 };
+
+exports.uncached_resources = [];


### PR DESCRIPTION
@ozten - mind reviewing?

When looking for the filename, strip the fragment identifier (#partofurl) from the resource name.

The part that I am most concerned about is the exports.uncached_resources that I added. Is there a better way to check whether a resource cannot be found and no hash can be created?
