### PR TITLE
Simplify 'invalid cashes' verification

### DIFF
--- a/lib/connect-cachify.js
+++ b/lib/connect-cachify.js
@@ -14,7 +14,8 @@ var crypto = require('crypto'),
 var existsSync = fs.existsSync || path.existsSync,
     opts,
     _assets,
-    _cache = {};
+    _cache = {},
+    _hashes = {};
 
 exports.setup = function (assets, options) {
   _assets = assets;
@@ -103,33 +104,22 @@ exports.setup = function (assets, options) {
         }
       }
 
-      // determine actual current hash of the file, it's worth the disk
-      // read to ensure we never serve bogus resources and poison caches
-      // issue #31
-      fs.readFile(true_path, function(err, contents) {
-        // ignore error
-        var md5 = crypto.createHash('md5');
-        if (contents) md5.update(contents);
-        var actualHash = md5.digest('hex').slice(0, 10);
-
-        if (exists === true && hash === actualHash) {
-          resp.setHeader('Cache-Control', 'public, max-age=31536000');
-          req.url = url;
-          if (opts.control_headers === true) {
-            resp.on('header', function () {
-              // Relax other middleware... I got this one
-              ['ETag', 'Last-Modified'].forEach(function (header) {
-                if (resp.getHeader(header)) resp.removeHeader(header);
-                if (resp.getHeader(header)) resp.removeHeader(header);
-              });
+      // determine if we actually generated a hash like that
+      if (exists === true && _hashes[hash]) {
+        resp.setHeader('Cache-Control', 'public, max-age=31536000');
+        req.url = url;
+        if (opts.control_headers === true) {
+          resp.on('header', function () {
+            // Relax other middleware... I got this one
+            ['ETag', 'Last-Modified'].forEach(function (header) {
+              if (resp.getHeader(header)) resp.removeHeader(header);
+              if (resp.getHeader(header)) resp.removeHeader(header);
             });
-          }
+          });
         }
-        next();
-      });
-    } else {
-      next();
+      }
     }
+    next();
   };
 };
 
@@ -185,6 +175,8 @@ var hashify = function (resource, hash) {
       return resource;
     }
   }
+  // store generated hash
+  _hashes[hash] = 1;
   if (opts.prefix.indexOf('://') === -1 &&
       resource[0] === '/') {
     return format('/%s%s%s', opts.prefix, hash, resource);


### PR DESCRIPTION
Instead of checking cachify prefix against the md5 hash of the file content we just check if the said prefix is among the ones that we previously generated.

It provides a safeguard against someone maliciously attempting to clog the downstream cache by sending us a great number of invalid URLs and has an added benefit of beeing much simpler than 'recalculate the hash' method.

Fixes #37
