### PR TITLE
Added support for express 4.x

### DIFF
--- a/lib/connect-cachify.js
+++ b/lib/connect-cachify.js
@@ -17,124 +17,134 @@ var existsSync = fs.existsSync || path.existsSync,
     _assets,
     _cache = {};
 
-exports.setup = function (assets, options) {
-  _assets = assets;
-  if (!options) options = {};
-  opts = options;
-  if (options.production === undefined) {
-    opts.production = true;
-  }
-  if (!options.root) opts.root = '.';
-  if (!options.url_to_paths) opts.url_to_paths = {};
-  if (!options.prefix) {
-    opts.prefix = '';
-  // Must end with a '/'
-  } else if (options.prefix.slice(-1) !== '/') {
-    opts.prefix += '/';
-  }
-  // Don't lead with a '/'
-  if (opts.prefix.charAt(0) === '/') {
-    opts.prefix = opts.prefix.slice(1);
-  }
-  if (options.control_headers === undefined) {
-    opts.control_headers = false;
-  }
-  if (options.debug === undefined) {
-    opts.debug = false;
-  }
-
-  return function (req, resp, next) {
-    // If the first path element is a md5 hash AND one of the following:
-    // * the path is opts.prefix
-    // * the filename is a key in our opts[family]
-    // * or the file exists on the filesystem
-    var prefix = escape_regex(no_url(opts.prefix)),
-        req_url = url.parse(req.url),
-        uri = req_url.pathname ? req_url.pathname : '',
-        fmt = format('^\\/%s[a-f0-9]{10}', prefix),
-        m = uri.match(new RegExp(fmt)),
-        true_path, exists;
-
-    if (typeof resp.local === 'function') {
-      resp.local('cachify_prefetch', cachify_prefetch);
-      resp.local('cachify_js', cachify_js);
-      resp.local('cachify_css', cachify_css);
-      resp.local('cachify', cachify);
+exports.setup = function(assets, options) {
+    _assets = assets;
+    if (!options) options = {};
+    opts = options;
+    if (options.production === undefined) {
+        opts.production = true;
     }
-    else if (typeof resp.locals === 'function') {
-      resp.locals({
-        cachify_prefetch: cachify_prefetch,
-        cachify_js: cachify_js,
-        cachify_css: cachify_css,
-        cachify: cachify
-      });
+    if (!options.root) opts.root = '.';
+    if (!options.url_to_paths) opts.url_to_paths = {};
+    if (!options.prefix) {
+        opts.prefix = '';
+        // Must end with a '/'
+    } else if (options.prefix.slice(-1) !== '/') {
+        opts.prefix += '/';
     }
-    if (m && m.index === 0) {
-      // extract the hash
-      var hash = uri.slice(prefix.length + 1, prefix.length + 11);
-      // 10 first characters of md5 + 1 for slash
-      var _url = uri.slice(prefix.length + 11);
-      true_path = opts.url_to_paths[_url] || path.join(opts.root, _url);
+    // Don't lead with a '/'
+    if (opts.prefix.charAt(0) === '/') {
+        opts.prefix = opts.prefix.slice(1);
+    }
+    if (options.control_headers === undefined) {
+        opts.control_headers = false;
+    }
+    if (options.debug === undefined) {
+        opts.debug = false;
+    }
 
-      exists = false;
+    return function(req, resp, next) {
+        // If the first path element is a md5 hash AND one of the following:
+        // * the path is opts.prefix
+        // * the filename is a key in our opts[family]
+        // * or the file exists on the filesystem
+        var prefix = escape_regex(no_url(opts.prefix)),
+            req_url = url.parse(req.url),
+            uri = req_url.pathname ? req_url.pathname : '',
+            fmt = format('^\\/%s[a-f0-9]{10}', prefix),
+            m = uri.match(new RegExp(fmt)),
+            true_path, exists;
 
-      if (opts.prefix !== '' &&
-          uri.indexOf('/' + opts.prefix) === 0) {
-        exists = true;
-      } else if (assets[true_path]) {
-        exists = true;
-      }
-
-      if (exists === false) {
-        if (_cache[true_path]) {
-          if (_cache[true_path].exists === true) {
-            exists = true;
-          }
-        } else {
-          // Would we ever want to use cachify for non-file resources?
-          if (existsSync(true_path)) {
-            exists = true;
-            _cache[true_path] = {exists: true};
-          } else {
-            // Hmm potential DOS Attack here... maybe we shouldn't cache
-            // checking disk every time isn't that bad - just like static
-            // middleware
-            // Or use an LRU?
-            console.warn('Cachify like URL, but no file found');
-            _cache[true_path] = {exists: false};
-          }
-        }
-      }
-
-      // determine actual current hash of the file, it's worth the disk
-      // read to ensure we never serve bogus resources and poison caches
-      // issue #31
-      fs.readFile(true_path, function(err, contents) {
-        // ignore error
-        var md5 = crypto.createHash('md5');
-        if (contents) md5.update(contents);
-        var actualHash = md5.digest('hex').slice(0, 10);
-
-        if (exists === true && hash === actualHash) {
-          resp.setHeader('Cache-Control', 'public, max-age=31536000');
-          // append back the query string and Hash if any
-          req.url = _url + (req_url.query ? '?' + req_url.query : '') + (req_url.hash ?  req_url.hash : '');
-          if (opts.control_headers === true) {
-            resp.on('header', function () {
-              // Relax other middleware... I got this one
-              ['ETag', 'Last-Modified'].forEach(function (header) {
-                if (resp.getHeader(header)) resp.removeHeader(header);
-                if (resp.getHeader(header)) resp.removeHeader(header);
-              });
+        if (typeof resp.local === 'function') {
+            resp.local('cachify_prefetch', cachify_prefetch);
+            resp.local('cachify_js', cachify_js);
+            resp.local('cachify_css', cachify_css);
+            resp.local('cachify', cachify);
+        } else if (typeof resp.locals === 'function') {
+            resp.locals({
+                cachify_prefetch: cachify_prefetch,
+                cachify_js: cachify_js,
+                cachify_css: cachify_css,
+                cachify: cachify
             });
-          }
+        } // This is a fix for Express 4.x in which resp.locals is now an object instead of a function
+        else if (typeof resp.locals === 'object') {
+
+            resp.locals.cachify_prefetch = cachify_prefetch,
+            resp.locals.cachify_js = cachify_js,
+            resp.locals.cachify_css = cachify_css,
+            resp.locals.cachify = cachify
         }
-        next();
-      });
-    } else {
-      next();
-    }
-  };
+        if (m && m.index === 0) {
+            // extract the hash
+            var hash = uri.slice(prefix.length + 1, prefix.length + 11);
+            // 10 first characters of md5 + 1 for slash
+            var _url = uri.slice(prefix.length + 11);
+            true_path = opts.url_to_paths[_url] || path.join(opts.root, _url);
+
+            exists = false;
+
+            if (opts.prefix !== '' &&
+                uri.indexOf('/' + opts.prefix) === 0) {
+                exists = true;
+            } else if (assets[true_path]) {
+                exists = true;
+            }
+
+            if (exists === false) {
+                if (_cache[true_path]) {
+                    if (_cache[true_path].exists === true) {
+                        exists = true;
+                    }
+                } else {
+                    // Would we ever want to use cachify for non-file resources?
+                    if (existsSync(true_path)) {
+                        exists = true;
+                        _cache[true_path] = {
+                            exists: true
+                        };
+                    } else {
+                        // Hmm potential DOS Attack here... maybe we shouldn't cache
+                        // checking disk every time isn't that bad - just like static
+                        // middleware
+                        // Or use an LRU?
+                        console.warn('Cachify like URL, but no file found');
+                        _cache[true_path] = {
+                            exists: false
+                        };
+                    }
+                }
+            }
+
+            // determine actual current hash of the file, it's worth the disk
+            // read to ensure we never serve bogus resources and poison caches
+            // issue #31
+            fs.readFile(true_path, function(err, contents) {
+                // ignore error
+                var md5 = crypto.createHash('md5');
+                if (contents) md5.update(contents);
+                var actualHash = md5.digest('hex').slice(0, 10);
+
+                if (exists === true && hash === actualHash) {
+                    resp.setHeader('Cache-Control', 'public, max-age=31536000');
+                    // append back the query string and Hash if any
+                    req.url = _url + (req_url.query ? '?' + req_url.query : '') + (req_url.hash ? req_url.hash : '');
+                    if (opts.control_headers === true) {
+                        resp.on('header', function() {
+                            // Relax other middleware... I got this one
+                            ['ETag', 'Last-Modified'].forEach(function(header) {
+                                if (resp.getHeader(header)) resp.removeHeader(header);
+                                if (resp.getHeader(header)) resp.removeHeader(header);
+                            });
+                        });
+                    }
+                }
+                next();
+            });
+        } else {
+            next();
+        }
+    };
 };
 
 /**
@@ -145,129 +155,131 @@ exports.setup = function (assets, options) {
  * foo.js                    -> a998d8e98f/foo.js
  * http://example.com/foo.js -> http://example.com/foo.js
  */
-var hashify = function (resource, hash) {
-  if (typeof resource !== 'string')
-    throw "cachify ERROR, expected string for resource, got " + resource;
-  if (resource.indexOf('://') !== -1) {
-    return resource;
-  }
-
-  if (! hash && opts.global_hash) {
-    hash = opts.global_hash;
-  }
-
-  if (opts.production !== true &&
-      opts.debug === false) {
-    return resource;
-  }
-
-  // fragment identifiers on URLs are never sent to the server and they
-  // should not exist on the filename. When looking up the resource on
-  // disk, do so without the fragment identifier.
-  var url = resource.replace(/#.*$/, '');
-  var filename = opts.url_to_paths[url] || path.join(opts.root, url);
-
-  if (hash) {
-    // No-op, specifing a hash skips all this craziness
-  } else if (_cache[filename] && _cache[filename].hash) {
-    hash = _cache[filename].hash;
-    //console.info('cache hit ', filename);
-  } else {
-    //console.info('cache miss ', filename);
-    var md5 = crypto.createHash('md5');
-    try {
-      var data = fs.readFileSync(filename);
-      md5.update(data);
-      // Expensive, maintain in-memory cache
-      if (! _cache[filename]) _cache[filename] = {exists: true};
-      hash = _cache[filename].hash = md5.digest('hex').slice(0, 10);
-    } catch (e) {
-      // Not intersting to cache, programmer error?
-      exports.uncached_resources.push(resource);
-      console.error('Cachify bailing on hash... no such file ' + filename );
-      console.error(e);
-      return resource;
+var hashify = function(resource, hash) {
+    if (typeof resource !== 'string')
+        throw "cachify ERROR, expected string for resource, got " + resource;
+    if (resource.indexOf('://') !== -1) {
+        return resource;
     }
-  }
-  if (opts.prefix.indexOf('://') === -1 &&
-      resource[0] === '/') {
-    return format('/%s%s%s', opts.prefix, hash, resource);
-  } else {
-    return format('%s%s%s%s', opts.prefix, hash, resource[0] === '/' ? '' : '/', resource);
-  }
+
+    if (!hash && opts.global_hash) {
+        hash = opts.global_hash;
+    }
+
+    if (opts.production !== true &&
+        opts.debug === false) {
+        return resource;
+    }
+
+    // fragment identifiers on URLs are never sent to the server and they
+    // should not exist on the filename. When looking up the resource on
+    // disk, do so without the fragment identifier.
+    var url = resource.replace(/#.*$/, '');
+    var filename = opts.url_to_paths[url] || path.join(opts.root, url);
+
+    if (hash) {
+        // No-op, specifing a hash skips all this craziness
+    } else if (_cache[filename] && _cache[filename].hash) {
+        hash = _cache[filename].hash;
+        //console.info('cache hit ', filename);
+    } else {
+        //console.info('cache miss ', filename);
+        var md5 = crypto.createHash('md5');
+        try {
+            var data = fs.readFileSync(filename);
+            md5.update(data);
+            // Expensive, maintain in-memory cache
+            if (!_cache[filename]) _cache[filename] = {
+                exists: true
+            };
+            hash = _cache[filename].hash = md5.digest('hex').slice(0, 10);
+        } catch (e) {
+            // Not intersting to cache, programmer error?
+            exports.uncached_resources.push(resource);
+            console.error('Cachify bailing on hash... no such file ' + filename);
+            console.error(e);
+            return resource;
+        }
+    }
+    if (opts.prefix.indexOf('://') === -1 &&
+        resource[0] === '/') {
+        return format('/%s%s%s', opts.prefix, hash, resource);
+    } else {
+        return format('%s%s%s%s', opts.prefix, hash, resource[0] === '/' ? '' : '/', resource);
+    }
 };
 
-var prod_or_dev_tags = function (filename, link_fmt, hash) {
-  var req_url = url.parse(filename),
-      uri = req_url.pathname ? req_url.pathname : '';
-  if (opts.production !== true &&
-    _assets[uri]) {
-    return und.map(_assets[uri], function (f) {
-      var asset_url = url.parse(f),
-      asset_uri = asset_url.pathname ? asset_url.pathname : '';
-      return format(link_fmt, hashify(asset_uri + (req_url.query ? '?' + req_url.query : '') + (asset_url.hash ?  asset_url.hash : ''), hash));
-    }).join('\n');
-  }
-  return format(link_fmt, hashify(filename, hash));
+var prod_or_dev_tags = function(filename, link_fmt, hash) {
+    var req_url = url.parse(filename),
+        uri = req_url.pathname ? req_url.pathname : '';
+    if (opts.production !== true &&
+        _assets[uri]) {
+        return und.map(_assets[uri], function(f) {
+            var asset_url = url.parse(f),
+                asset_uri = asset_url.pathname ? asset_url.pathname : '';
+            return format(link_fmt, hashify(asset_uri + (req_url.query ? '?' + req_url.query : '') + (asset_url.hash ? asset_url.hash : ''), hash));
+        }).join('\n');
+    }
+    return format(link_fmt, hashify(filename, hash));
 };
 
-var cachify_js = exports.cachify_js = function (filename, options) {
-  if (! options) options = {};
-  var link_fmt = '<script src="%s"';
+var cachify_js = exports.cachify_js = function(filename, options) {
+    if (!options) options = {};
+    var link_fmt = '<script src="%s"';
 
-  /**
-   * indicate to a browser that the script is meant to be executed after the
-   * document has been parsed.
-   */
-  if (options.defer && opts.production === true) {
-    link_fmt += ' defer';
-  }
+    /**
+     * indicate to a browser that the script is meant to be executed after the
+     * document has been parsed.
+     */
+    if (options.defer && opts.production === true) {
+        link_fmt += ' defer';
+    }
 
-  /**
-   * indicate that the browser should, if possible, execute the script
-   * asynchronously
-   */
-  if (options.async && opts.production === true) {
-    link_fmt += ' async';
-  }
+    /**
+     * indicate that the browser should, if possible, execute the script
+     * asynchronously
+     */
+    if (options.async && opts.production === true) {
+        link_fmt += ' async';
+    }
 
-  link_fmt += '></script>';
-  return prod_or_dev_tags(filename, link_fmt, options.hash);
+    link_fmt += '></script>';
+    return prod_or_dev_tags(filename, link_fmt, options.hash);
 };
 
-var cachify_css = exports.cachify_css = function (filename, options) {
-  if (! options) options = {};
-  return prod_or_dev_tags(filename,
-                          '<link href="%s" rel="stylesheet" type="text/css">',
-                          options.hash);
+var cachify_css = exports.cachify_css = function(filename, options) {
+    if (!options) options = {};
+    return prod_or_dev_tags(filename,
+        '<link href="%s" rel="stylesheet" type="text/css">',
+        options.hash);
 };
 
-var cachify_prefetch = exports.cachify_prefetch = function (filename, options) {
-  if (! options) options = {};
-  return prod_or_dev_tags(filename,
-                          '<link rel="prefetch" href="%s">',
-                          options.hash);
+var cachify_prefetch = exports.cachify_prefetch = function(filename, options) {
+    if (!options) options = {};
+    return prod_or_dev_tags(filename,
+        '<link rel="prefetch" href="%s">',
+        options.hash);
 };
 
-var cachify = exports.cachify = function (filename, options) {
-  var tag_format;
-  if (! options) options = {};
-  if (options.tag_format)
-      tag_format = options.tag_format;
-  else
-      tag_format = '%s';
-  return prod_or_dev_tags(filename, tag_format, options.hash);
+var cachify = exports.cachify = function(filename, options) {
+    var tag_format;
+    if (!options) options = {};
+    if (options.tag_format)
+        tag_format = options.tag_format;
+    else
+        tag_format = '%s';
+    return prod_or_dev_tags(filename, tag_format, options.hash);
 };
 
-var no_url = function (prefix) {
-  if (prefix.indexOf('://') === -1) return prefix;
-  var m = prefix.match(/^[a-z]{3,5}:\/\/[a-z0-9\-_.]*(?:\:[0-9]*)?\/(.*)$/i);
-  if (m) return m[1];
-  else return prefix;
+var no_url = function(prefix) {
+    if (prefix.indexOf('://') === -1) return prefix;
+    var m = prefix.match(/^[a-z]{3,5}:\/\/[a-z0-9\-_.]*(?:\:[0-9]*)?\/(.*)$/i);
+    if (m) return m[1];
+    else return prefix;
 };
 
-var escape_regex = function (str) {
-  return str.replace('/', '\/');
+var escape_regex = function(str) {
+    return str.replace('/', '\/');
 };
 
 exports.uncached_resources = [];

--- a/test/express-test.js
+++ b/test/express-test.js
@@ -52,7 +52,6 @@ exports.setup = nodeunit.testCase({
                 } else if (1 === i) {
                     express3 = require(path.join(express3dir, 'node_modules/express'));
                 } else {
-                    console.log(cb);
                     express4 = require(path.join(express4dir, 'node_modules/express'));
                     cb();
                 }

--- a/test/express-test.js
+++ b/test/express-test.js
@@ -1,85 +1,106 @@
 /* Test Express 2.x to maintain compatability                                 */
 
 var cachify = require('../lib/connect-cachify'),
-express2,
-express3,
-http = require('http'),
-nodeunit = require('nodeunit'),
-os = require('os'),
-path = require('path'),
-shell = require('shelljs'),
-spawn = require('child_process').spawn;
+    express2,
+    express3,
+    express4,
+    http = require('http'),
+    nodeunit = require('nodeunit'),
+    os = require('os'),
+    path = require('path'),
+    shell = require('shelljs'),
+    spawn = require('child_process').spawn;
 
 var tmpDir = os.tmpDir ? os.tmpDir() : '/tmp';
 
 var express2dir = path.join(tmpDir, 'connect-cachify-express2-test');
 var express3dir = path.join(tmpDir, 'connect-cachify-express3-test');
+var express4dir = path.join(tmpDir, 'connect-cachify-express4-test');
 
 const EXPRESS_2_VER = '2.5.10';
 const EXPRESS_3_VER = '3.0.0rc5';
+const EXPRESS_4_VER = '4.0.0';
 
 exports.setup = nodeunit.testCase({
-  setUp: function (cb) {
-    [{dir: express2dir, ver: '2.5.10'}, 
-     {dir: express3dir, ver: EXPRESS_3_VER}].forEach(function (express, i) {
-       console.log('Creating ' + express.dir);
-       shell.mkdir('-p', express.dir);
-       process.chdir(express.dir);
+    setUp: function(cb) {
+        [{
+            dir: express2dir,
+            ver: EXPRESS_2_VER
+        }, {
+            dir: express3dir,
+            ver: EXPRESS_3_VER
+        }, {
+            dir: express4dir,
+            ver: EXPRESS_4_VER
+        }].forEach(function(express, i) {
+            console.log('Creating ' + express.dir);
+            shell.mkdir('-p', express.dir);
+            process.chdir(express.dir);
 
-       var npm = spawn('npm', ['install', 'express@' + express.ver], {});
-       var debug = function (data) { process.stdout.write(data.toString('utf8')); };
-       npm.stdout.on('data', debug);
-       npm.stderr.on('data', debug);
-       npm.on('exit', function (code) {
-         if (0 !== code) {
-           throw new Error('Unable to npm install express');
-         }
-         if (0 === i) {
-           express2 = require(path.join(express2dir, 'node_modules/express'));
-         } else {
-           express3 = require(path.join(express3dir, 'node_modules/express')); 
-           cb();
-         }
-       });
-     });
-  },
-  tearDown: function (cb) {
-    [express2dir, express3dir].forEach(function (expressDir) {
-      console.log('Removing ' + expressDir);
-      shell.rm('-rf', expressDir);
-    });
-    cb();
-  },
-  "Run Server": function (test) {
-    test.equal(express2.version, EXPRESS_2_VER);
-    test.equal(express3.version, EXPRESS_3_VER);
-    [express2, express3].forEach(function (express, i) {
-      var app = i === 0 ? express.createServer() : express();
-      app.use(cachify.setup([]));
-      app.use(function (req, res, next) {
-        var locals = res.locals();
-        test.ok(!! locals.cachify);
-        test.ok(!! locals.cachify_css);
-        test.ok(!! locals.cachify_js);
-        test.ok(!! locals.cachify_prefetch);
-        res.send('ok');
-      });
-      var server = app.listen(0);
-      var port = server.address().port;
-      console.log('Started web server on port ' + port);
-      var resText = "";
-      var req = http.request({ port: port, path: '/baddecafe1/foo.js'}, function (res) {
-        test.equal(res.statusCode, 200);
-        res.on('data', function (chunk) {
-          resText += chunk;
+            var npm = spawn('npm', ['install', 'express@' + express.ver], {});
+            var debug = function(data) {
+                process.stdout.write(data.toString('utf8'));
+            };
+            npm.stdout.on('data', debug);
+            npm.stderr.on('data', debug);
+            npm.on('exit', function(code) {
+                if (0 !== code) {
+                    throw new Error('Unable to npm install express');
+                }
+                if (0 === i) {
+                    express2 = require(path.join(express2dir, 'node_modules/express'));
+                } else if (1 === i) {
+                    express3 = require(path.join(express3dir, 'node_modules/express'));
+                } else {
+                    console.log(cb);
+                    express4 = require(path.join(express4dir, 'node_modules/express'));
+                    cb();
+                }
+            });
         });
-        res.on('end', function () {
-          test.equal(resText, 'ok');
-          app.close ? app.close() : server.close();
-          if (1 === i) test.done();
+    },
+    tearDown: function(cb) {
+        [express2dir, express3dir, express3dir].forEach(function(expressDir) {
+            console.log('Removing ' + expressDir);
+            shell.rm('-rf', expressDir);
         });
-      });
-      req.end();
-    });
-  }
+        cb();
+    },
+    "Run Server": function(test) {
+        test.equal(express2.version, EXPRESS_2_VER);
+        test.equal(express3.version, EXPRESS_3_VER);
+        // Express 4 doesn't have a version so check for a property instead
+        test.ok( !! express4.Router);
+        [express2, express3, express4].forEach(function(express, i) {
+            var app = i === 0 ? express.createServer() : express();
+            app.use(cachify.setup([]));
+            app.use(function(req, res, next) {
+                var locals = typeof res.locals === 'function' ? res.locals() : res.locals;
+                test.ok( !! locals.cachify);
+                test.ok( !! locals.cachify_css);
+                test.ok( !! locals.cachify_js);
+                test.ok( !! locals.cachify_prefetch);
+                res.send('ok');
+            });
+            var server = app.listen(0);
+            var port = server.address().port;
+            console.log('Started web server on port ' + port);
+            var resText = "";
+            var req = http.request({
+                port: port,
+                path: '/baddecafe1/foo.js'
+            }, function(res) {
+                test.equal(res.statusCode, 200);
+                res.on('data', function(chunk) {
+                    resText += chunk;
+                });
+                res.on('end', function() {
+                    test.equal(resText, 'ok');
+                    app.close ? app.close() : server.close();
+                    if (1 === i) test.done();
+                });
+            });
+            req.end();
+        });
+    }
 });


### PR DESCRIPTION
Express 4.x no longer uses a function to represent res.locals.  This is a fix for supporting 4.x and remains backwards compatible with 3 and 2.
